### PR TITLE
Add mobile-first single-page site for The Thrift

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,17 +1,18 @@
-<!DOCTYPE html><html lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>The Thrift | Girard, PA</title>
-  <!-- Link to external stylesheet -->
   <link rel="stylesheet" href="styles.css" />
 </head>
 <body>
   <!-- Header -->
-  <header>
+  <header class="site-header">
     <div class="container">
-      <h1 class="logo">The Thrift</h1>
-      <nav>
+      <!-- Replace src with your logo file -->
+      <img src="logo-placeholder.png" alt="The Thrift logo" class="logo" />
+      <nav class="site-nav">
         <ul>
           <li><a href="#home">Home</a></li>
           <li><a href="#about">About</a></li>
@@ -20,70 +21,91 @@
         </ul>
       </nav>
     </div>
-  </header>  <!-- Hero Section -->  <section id="home" class="hero">
-    <!-- Replace with a full-width background image in CSS -->
+  </header>
+
+  <!-- Hero -->
+  <section id="home" class="hero">
     <div class="hero-content">
-      <h2>Discover Hidden Gems in Girard, PA</h2>
-      <p>Your family-owned thrift shop is waiting.</p>
+      <h1>Discover Hidden Gems in Girard, PA</h1>
+      <p>Vintage treasures, budget-friendly finds, and more.</p>
       <a href="#contact" class="btn">Visit Us In-Store</a>
     </div>
-  </section>  <!-- About Section -->  <section id="about" class="about">
-    <div class="container about-content">
+  </section>
+
+  <!-- About -->
+  <section id="about" class="about">
+    <div class="container about-grid">
       <div class="about-text">
-        <h3>Family-Owned Since 19XX</h3>
-        <p><!-- Write your store history here --></p>
+        <h2>Family-Owned Since 19XX</h2>
+        <p><!-- Add your store history or mission statement here --></p>
       </div>
       <div class="about-image">
-        <!-- Replace with family/store photo -->
-        <img src="placeholder-about.jpg" alt="Family-owned thrift shop" />
+        <!-- Replace src with your own photo -->
+        <img src="about-placeholder.jpg" alt="Inside The Thrift" />
       </div>
     </div>
-  </section>  <!-- Featured Finds Section -->  <section id="finds" class="finds">
+  </section>
+
+  <!-- Featured Finds -->
+  <section id="finds" class="finds">
     <div class="container">
-      <h3>Featured Finds</h3>
-      <div class="grid">
+      <h2>Featured Finds</h2>
+      <div class="finds-grid">
         <!-- Repeat this block for each item -->
-        <div class="item">
-          <img src="placeholder-item.jpg" alt="Item Name" />
-          <h4>Item Name</h4>
-          <p>$Price</p>
+        <div class="find-item">
+          <!-- Replace src with item image -->
+          <img src="item-placeholder.jpg" alt="Item Name" />
+          <h3>Item Name</h3>
+          <p>$0.00</p>
         </div>
         <!-- End item block -->
       </div>
     </div>
-  </section>  <!-- Contact Section -->  <section id="contact" class="contact">
-    <div class="container contact-content">
+  </section>
+
+  <!-- Contact -->
+  <section id="contact" class="contact">
+    <div class="container contact-grid">
       <div class="contact-info">
-        <h3>Contact & Store Info</h3>
-        <p>123 Main Street, Girard, PA 16417</p>
-        <p>Mon–Sat: 9am – 6pm</p>
-        <p>Sun: Closed</p>
-        <!-- Google Maps Embed -->
+        <h2>Contact & Store Info</h2>
+        <p>123 Main Street<br />Girard, PA 16417</p>
+        <p>Mon–Sat: 9am–6pm<br />Sun: Closed</p>
+        <!-- Replace src with actual Google Maps embed -->
         <iframe
-          src="https://www.google.com/maps/embed?pb=..."
-          width="100%" height="250" style="border:0;" allowfullscreen="" loading="lazy">
-        </iframe>
+          src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d0!2d0!3d0"
+          loading="lazy"
+          allowfullscreen=""
+        ></iframe>
       </div>
       <div class="contact-form">
-        <h3>Get in Touch</h3>
+        <h2>Get in Touch</h2>
         <form action="#" method="post">
           <label for="name">Name</label>
-          <input type="text" id="name" name="name" required /><label for="email">Email</label>
-      <input type="email" id="email" name="email" required />
+          <input id="name" name="name" type="text" required />
 
-      <label for="message">Message</label>
-      <textarea id="message" name="message" rows="4" required></textarea>
+          <label for="email">Email</label>
+          <input id="email" name="email" type="email" required />
 
-      <button type="submit">Send Message</button>
-    </form>
-  </div>
-</div>
+          <label for="message">Message</label>
+          <textarea id="message" name="message" rows="4" required></textarea>
 
-  </section>  <!-- Footer -->  <footer>
+          <button type="submit">Send Message</button>
+        </form>
+      </div>
+    </div>
+  </section>
+
+  <!-- Footer -->
+  <footer class="site-footer">
     <div class="container">
       <p>&copy; 2025 The Thrift, Girard, PA</p>
       <ul class="social">
-        <li><a href="https://www.facebook.com/share/15r8Zz4ZjT/" target="_blank">Facebook</a></li>
+        <li>
+          <!-- Replace href with your Facebook page -->
+          <a href="https://www.facebook.com/" target="_blank" rel="noopener"
+            >Facebook</a
+          >
+        </li>
       </ul>
     </div>
   </footer>

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,155 @@
+:root {
+  --color-bg: #ffffff;
+  --color-text: #333333;
+  --color-accent: #4caf50;
+}
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: Arial, sans-serif;
+  background: var(--color-bg);
+  color: var(--color-text);
+}
+
+.container {
+  width: 90%;
+  max-width: 1200px;
+  margin: 0 auto;
+}
+
+/* Header */
+.site-header {
+  background: var(--color-bg);
+  border-bottom: 1px solid #eee;
+}
+.site-header .container {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1rem 0;
+}
+.logo {
+  width: 120px;
+  /* Update width and replace image as needed */
+}
+.site-nav ul {
+  list-style: none;
+  display: flex;
+  gap: 1rem;
+  margin: 0;
+  padding: 0;
+}
+.site-nav a {
+  text-decoration: none;
+  color: var(--color-text);
+}
+
+/* Hero */
+.hero {
+  /* Replace URL with hero background image */
+  background: url('hero-placeholder.jpg') center/cover no-repeat;
+  color: var(--color-bg);
+  text-align: center;
+  padding: 4rem 1rem;
+}
+.hero .btn {
+  display: inline-block;
+  margin-top: 1rem;
+  padding: 0.75rem 1.5rem;
+  background: var(--color-accent);
+  color: #fff;
+  text-decoration: none;
+  border-radius: 4px;
+}
+
+/* About */
+.about-grid {
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+.about-image img {
+  width: 100%;
+  height: auto;
+}
+
+/* Featured Finds */
+.finds-grid {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: 1fr;
+}
+.find-item img {
+  width: 100%;
+  height: auto;
+}
+
+/* Contact */
+.contact-grid {
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+.contact-info iframe {
+  width: 100%;
+  height: 250px;
+  border: 0;
+}
+.contact-form form {
+  display: flex;
+  flex-direction: column;
+}
+.contact-form input,
+.contact-form textarea {
+  margin-bottom: 1rem;
+  padding: 0.5rem;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+}
+.contact-form button {
+  padding: 0.75rem 1rem;
+  background: var(--color-accent);
+  color: #fff;
+  border: none;
+  border-radius: 4px;
+}
+
+/* Footer */
+.site-footer {
+  background: #f5f5f5;
+  text-align: center;
+  padding: 1rem 0;
+  margin-top: 2rem;
+}
+.site-footer .social {
+  list-style: none;
+  padding: 0;
+  margin: 0.5rem 0 0;
+}
+.site-footer .social li {
+  display: inline-block;
+  margin: 0 0.5rem;
+}
+
+/* Media Queries */
+@media (min-width: 600px) {
+  .about-grid {
+    flex-direction: row;
+    align-items: center;
+  }
+
+  .contact-grid {
+    flex-direction: row;
+    align-items: flex-start;
+  }
+
+  .finds-grid {
+    grid-template-columns: repeat(3, 1fr);
+  }
+}


### PR DESCRIPTION
## Summary
- Build single-page HTML5 + CSS site for The Thrift with header, hero, about, featured finds, contact, and footer sections.
- Introduce responsive layout using CSS variables, flexbox/grid, and media queries for mobile-first design.

## Testing
- `npx --yes htmlhint index.html`
- `npx --yes stylelint styles.css` *(fails: No configuration provided)*

------
https://chatgpt.com/codex/tasks/task_e_688ea52d4380833187fdeea9b047a1dd